### PR TITLE
Support feature to ignore fields with arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ const fieldsToRelations = require('fieldsToRelations');
 const relations = fieldsToRelations(info);
 ```
 
+In the case a field isn't actually a relation in your database you would like to exclude those fields. To exclude the fields pass an array to the options argument
+
+```
+const relations = fieldsToRelations(info, {
+  excludeFields: ['user.data']
+})
+```
+
+When the field has arguments it is likely the child resolver handles the relation. In that case you would like to exclude all fields that have arguments
+
+```
+const relations = fieldsToRelations(info, {
+  excludeFieldsWithArguments: true
+})
+```
+
 ## 🔍 Example
 
 As an example, take following query:

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,16 +3,21 @@ import graphqFields from 'graphql-fields';
 
 const fieldsToRelations = (
   info: GraphQLResolveInfo,
-  options: { depth?: number; root?: string; excludeFields?: string[] } = {
+  options: { depth?: number; root?: string; excludeFields?: string[]; excludeFieldsWithArguments?: boolean } = {
     depth: undefined,
     root: '',
     excludeFields: [],
+    excludeFieldsWithArguments: false,
   },
 ): string[] => {
   const paths: string[][] = [];
 
   const nested = (field: any, key: string = undefined as any, deep = 0, parent: string[] = []) => {
     if (Object.values(field).length === 0) {
+      return;
+    }
+
+    if (options.excludeFieldsWithArguments && Object.keys(field).includes('__arguments')) {
       return;
     }
 
@@ -36,10 +41,18 @@ const fieldsToRelations = (
   };
 
   const value = !options.root
-    ? graphqFields(info, {}, { excludedFields: options.excludeFields })
+    ? graphqFields(
+        info,
+        {},
+        { excludedFields: options.excludeFields, processArguments: options.excludeFieldsWithArguments },
+      )
     : options.root.split('.').reduce(function (p, prop) {
         return p[prop];
-      }, graphqFields(info, {}, { excludedFields: options.excludeFields }));
+      }, graphqFields(
+        info,
+        {},
+        { excludedFields: options.excludeFields, processArguments: options.excludeFieldsWithArguments },
+      ));
 
   nested(value, !!options.root ? options.root.split('.').pop() : undefined);
 


### PR DESCRIPTION
Hi Dries,

Thanks for the work on this project. It works like a charm in combination with MikroORM!

I was having some issues where I wanted to ignore fields that have arguments because I don't want to query the entire relation, but only a subset. I've added the functionality to ignore fields when they have arguments. By default it's disabled so it shouldn't affect current functionality. 